### PR TITLE
Fix site edit form for larger screen widths

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -203,7 +203,7 @@
 
         <form id="site-edit-form" action="" method="post">
 
-            <div class="col-lg-4 col-md-6 col-sm-12">
+            <div class="col-md-6 col-sm-12">
                 <table class="edit-table">
                     <tbody>
                     <tr>
@@ -289,7 +289,7 @@
                 </table>
             </div>
 
-            <div class="col-lg-4 col-md-6 col-sm-12">
+            <div class="col-md-6 col-sm-12">
                 <table class="edit-table">
                     <tbody>
                     <tr>


### PR DESCRIPTION
Fix site edit form for screen widths of 1200px or greater, which currently squishes the left side of the form the most introduced by #2.