### PR TITLE
Reload adjustments, additional icons

### DIFF
--- a/src/main/css/lib/bootstrap-override.css
+++ b/src/main/css/lib/bootstrap-override.css
@@ -11,14 +11,3 @@ body {
 .navbar-default .navbar-nav > li > a:hover, .navbar-default .navbar-nav > li > a:focus {
     background-color: #ddd;
 }
-.table-bordered th, .view-table th {
-    position: sticky;
-    top: 50px;
-    /* To prevent relative children from appearing above: */
-    z-index: 1;
-}
-.table-bordered th {
-    background-color: #fff;
-    box-shadow: inset 0px -1px 0px 0px #ddd;
-    border-bottom-width: 1px !important;
-}

--- a/src/main/css/lib/deferred-override.css
+++ b/src/main/css/lib/deferred-override.css
@@ -1,3 +1,18 @@
+/* Tables */
+.table-bordered th, .view-table th {
+    position: sticky;
+    top: 50px;
+    /* To prevent relative children from appearing above: */
+    z-index: 1;
+}
+.collapsing .table-bordered th, .collapsing .view-table th {
+    position: static;
+}
+.table-bordered th {
+    background-color: #fff;
+    box-shadow: inset 0px -1px 0px 0px #ddd;
+    border-bottom-width: 1px !important;
+}
 /* DataTables */
 div.dataTables_wrapper div.dataTables_middle {
     display: flex;

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -41,9 +41,11 @@
                     <a id="username-link" class="dropdown-toggle" data-toggle="dropdown" role="button"
                        aria-haspopup="true" aria-expanded="false" style="display: none"></a>
                     <ul class="dropdown-menu">
-                        <li><a class="page dropdown-item" id="page-link-account" href="#account">Account History</a></li>
+                        <li><a class="page dropdown-item" id="page-link-account" href="#account"><span
+                            class="glyphicon glyphicon-stats"></span> Account History</a></li>
                         <li class="divider"></li>
-                        <li><a id="logout-link" class="dropdown-item" href="#">Log Out</a></li>
+                        <li><a id="logout-link" class="dropdown-item" href="#"><span
+                            class="glyphicon glyphicon-log-out"></span> Log Out</a></li>
                     </ul>
 
                 </li>

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -473,15 +473,20 @@
 
         </form>
 
-        <table id="edit-site-detail-table" class="table table-condensed table-hover table-bordered">
-            <thead></thead>
-            <tbody></tbody>
-        </table>
+        <div class="collapse">
+            <table id="edit-site-detail-table" class="table table-condensed table-hover table-bordered">
+                <thead></thead>
+                <tbody></tbody>
+            </table>
+        </div>
 
-        <table id="edit-change-detail-table" class="table table-condensed table-hover table-bordered">
-            <thead></thead>
-            <tbody></tbody>
-        </table>
+        <div class="collapse">
+            <table id="edit-site-detail-table" class="table table-condensed table-hover table-bordered">
+            <table id="edit-change-detail-table" class="table table-condensed table-hover table-bordered">
+                <thead></thead>
+                <tbody></tbody>
+            </table>
+        </div>
 
         <table id="edit-sites-list-table" class="table table-condensed table-hover table-bordered" style="width:100%">
             <thead></thead>

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -178,10 +178,10 @@
     = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = -->
     <div id="page-comparison" class="page" style="display: none">
         <ul class="nav nav-pills" style="margin-bottom: 15px">
-            <li role="presentation" class="active"><a href="/service/supercharge/validation/webscrape" data-target="#validation-web-scrape-report">Worldwide</a></li>
-            <li role="presentation"><a href="/service/supercharge/validation/webscrape-china" data-target="#validation-web-scrape-china-report">China</a></li>
+            <li role="presentation" class="active"><a href="/service/supercharge/validation/webscrape" data-target="#validation-web-scrape-report"><span class="glyphicon glyphicon-globe"></span> Worldwide</a></li>
+            <li role="presentation"><a href="/service/supercharge/validation/webscrape-china" data-target="#validation-web-scrape-china-report"><span class="glyphicon glyphicon-plane"></span> China</a></li>
             <li role="presentation" class="dropdown">
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Json Sources <span class="caret" /></a>
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"><span class="glyphicon glyphicon-cloud-download"></span> Json Sources <span class="caret" /></a>
                 <ul class="dropdown-menu">
                     <li><a href="/service/supercharge/validation/tesla-source" target="_blank">Raw Worldwide Locations</a></li>
                     <li><a href="/service/supercharge/validation/china-source" target="_blank">Raw China Loations</a></li>
@@ -190,6 +190,7 @@
                     <li><a href="/service/supercharge/validation/processed-china-source" target="_blank">Processed China Locations</a></li>
                 </ul>
             </li>
+            <li role="presentation"><a href="#refresh"><span class="glyphicon glyphicon-refresh"></span> Refresh</a></li>
         </ul>
         <div id="validation-web-scrape-report" class="fade active in">
             <div class="dataTables_processing">
@@ -201,7 +202,7 @@
                 </div>
             </div>
         </div>
-        <div id="validation-web-scrape-china-report" class="fade" style="display: none">
+        <div id="validation-web-scrape-china-report" class="fade">
             <div class="dataTables_processing">
                 <div>
                     <div></div>
@@ -217,7 +218,7 @@
     PAGE: Validation
     = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = -->
     <div id="page-validation" class="page" style="display: none">
-        <div class="dataTables_processing">
+        <div class="dataTables_processing fade in">
             <div>
                 <div></div>
                 <div></div>

--- a/src/main/script/main.js
+++ b/src/main/script/main.js
@@ -4,4 +4,4 @@ import '../css/main.css';
 /* Turn off caching globally (adds a timestamp to the request parameters) */
 $.ajaxSetup({cache: false});
 
-new NavBar().setInitialPage();
+new NavBar();

--- a/src/main/script/page/account/AccountPage.js
+++ b/src/main/script/page/account/AccountPage.js
@@ -130,8 +130,17 @@ export default class AccountPage {
             event.preventDefault();
 
             const navHeight = $('.navbar-header').height() || $('.navbar').height();
+            const position = $(window).scrollTop();
             const input = $(this.dataTable.table().container()).find('input');
-            $('html').animate({ scrollTop: input.offset().top - navHeight - 10 }, { complete: () => input.focus() });
+            const options = {};
+
+            // Perform scroll
+            if (position + navHeight <= input.offset().top && position + $(window).height() >= input.offset().top + input.height()) {
+                input.focus().select();
+            } else {
+                options.complete = () => input.focus().select();
+            }
+            $('html').animate({ scrollTop: input.offset().top - navHeight - 10 }, options);
         }
     }
 

--- a/src/main/script/page/changeLog/ChangeLogPage.js
+++ b/src/main/script/page/changeLog/ChangeLogPage.js
@@ -20,10 +20,10 @@ export default class ChangeLogPage {
     }
 
     loadChangeLogList() {
-        $.getJSON(URL.change.list, $.proxy(this.populateChanges, this));
+        this.populateChanges();
     }
 
-    populateChanges(changeLogs) {
+    populateChanges() {
         if (!this.dataTable) {
             this.changeLogListTable.on("click", "a.change-log-delete-trigger", ChangeLogPage.handleDeleteClick);
 
@@ -38,7 +38,8 @@ export default class ChangeLogPage {
                 <th>Site Status</th>
             </tr>`);
             this.dataTable = this.changeLogListTable.DataTable({
-                data: changeLogs,
+                processing: true,
+                ajax: { url: URL.change.list, dataSrc: '' },
                 order: [[1, 'desc']],
                 lengthMenu: [25, 100, 1000, 20000],
                 columns: [
@@ -73,7 +74,7 @@ export default class ChangeLogPage {
             $(this.dataTable.table().container()).find('.row:first > div:eq(1)').text('All Changes');
             $(window).keydown($.proxy(this.handleFindShortcut, this));
         } else {
-            this.dataTable.clear().rows.add(changeLogs).draw();
+            this.dataTable.ajax.reload(null, false);
         }
     }
 

--- a/src/main/script/page/changeLog/ChangeLogPage.js
+++ b/src/main/script/page/changeLog/ChangeLogPage.js
@@ -82,8 +82,17 @@ export default class ChangeLogPage {
             event.preventDefault();
 
             const navHeight = $('.navbar-header').height() || $('.navbar').height();
+            const position = $(window).scrollTop();
             const input = $(this.dataTable.table().container()).find('input');
-            $('html').animate({ scrollTop: input.offset().top - navHeight - 10 }, { complete: () => input.focus() });
+            const options = {};
+
+            // Perform scroll
+            if (position + navHeight <= input.offset().top && position + $(window).height() >= input.offset().top + input.height()) {
+                input.focus().select();
+            } else {
+                options.complete = () => input.focus().select();
+            }
+            $('html').animate({ scrollTop: input.offset().top - navHeight - 10 }, options);
         }
     }
 

--- a/src/main/script/page/edit/ChangeDetailTable.js
+++ b/src/main/script/page/edit/ChangeDetailTable.js
@@ -6,6 +6,8 @@ import { sanitize } from 'dompurify';
 export default class ChangeDetailView {
     constructor() {
         this.table = $("#edit-site-detail-table");
+        this.table.parent().on("hidden.bs.collapse", () => this.table.find("tbody, thead").html(""));
+
         EventBus.addListener(EditEvents.load_history_trigger, this.loadHistory, this);
         EventBus.addListener(EditEvents.clear_panels, this.clearTable, this);
     }
@@ -46,11 +48,12 @@ export default class ChangeDetailView {
             </tr>`);
         });
 
+        this.table.parent().collapse('show');
         EventBus.dispatch(EditEvents.load_history_complete, true);
     }
 
     clearTable() {
-        this.table.find("tbody, thead").html("");
+        this.table.parent().collapse('hide');
         EventBus.dispatch(EditEvents.load_history_complete, false);
     }
 }

--- a/src/main/script/page/edit/ChangeLogTable.js
+++ b/src/main/script/page/edit/ChangeLogTable.js
@@ -12,6 +12,7 @@ export default class ChangeLogTable {
             .on("click", "a.edit-change-log", ChangeLogTable.handleEditClick)
             .on("click", "a.save-change-log", e => this.handleSaveClick(e))
             .on("click", "a.cancel-edit-change-log", ChangeLogTable.handleCancelClick);
+        this.table.parent().on("hidden.bs.collapse", () => this.table.find("thead, tbody").html(""));
 
         EventBus.addListener("change-log-deleted-event", this.handleDeletedChange, this);
         EventBus.addListener(EditEvents.load_change_log_trigger, this.loadHistory, this);
@@ -59,11 +60,12 @@ export default class ChangeLogTable {
             lastChangeType.html('UPDATE (<a href="#" class="fix-change-log">fix</a>)');
         }
 
+        this.table.parent().collapse('show');
         EventBus.dispatch(EditEvents.load_change_log_complete, true);
     }
 
     clearTable() {
-        this.table.find("tbody, thead").html("");
+        this.table.parent().collapse('hide');
         EventBus.dispatch(EditEvents.load_change_log_complete, false);
     }
 

--- a/src/main/script/page/edit/EditList.js
+++ b/src/main/script/page/edit/EditList.js
@@ -107,8 +107,17 @@ export default class EditList {
             event.preventDefault();
 
             const navHeight = $('.navbar-header').height() || $('.navbar').height();
+            const position = $(window).scrollTop();
             const input = $(this.dataTable.table().container()).find('input');
-            $('html').animate({ scrollTop: input.offset().top - navHeight - 10 }, { complete: () => input.focus() });
+            const options = {};
+
+            // Perform scroll
+            if (position + navHeight <= input.offset().top && position + $(window).height() >= input.offset().top + input.height()) {
+                input.focus().select();
+            } else {
+                options.complete = () => input.focus().select();
+            }
+            $('html').animate({ scrollTop: input.offset().top - navHeight - 10 }, options);
         }
     }
 

--- a/src/main/script/page/edit/EditList.js
+++ b/src/main/script/page/edit/EditList.js
@@ -22,14 +22,14 @@ export default class EditList {
     }
 
     loadSiteList() {
-        $.getJSON(URL.site.loadAll, $.proxy(this.populateEditSiteTable, this));
+        this.populateEditSiteTable();
     }
 
     deleteSite(event, siteId) {
         this.dataTable.row((i,d) => d.id == siteId).remove().draw();
     }
 
-    populateEditSiteTable(sites) {
+    populateEditSiteTable() {
         if (!this.dataTable) {
             this.siteListTable.on("click", "tbody tr", e => this.handleEditClick(e));
             const today = new Date();
@@ -48,7 +48,8 @@ export default class EditList {
                 <th>Links</th>
             </tr>`);
             this.dataTable = this.siteListTable.DataTable({
-                data: sites,
+                processing: true,
+                ajax: { url: URL.site.loadAll, dataSrc: '' },
                 order: [[8, 'desc']],
                 lengthMenu: [10, 25, 100, 1000, 10000],
                 columns: [
@@ -98,7 +99,7 @@ export default class EditList {
             $(this.dataTable.table().container()).find('.row:first > div:eq(1)').text('All Sites');
             $(window).keydown($.proxy(this.handleFindShortcut, this));
         } else {
-            this.dataTable.clear().rows.add(sites).draw();
+            this.dataTable.ajax.reload(null, false);
         }
     }
 


### PR DESCRIPTION
- Ctrl/cmd-f search box behavior improvements
  - Immediately focus if search box is in view
  - Highlight all text on focus to easily replace text
- Changes to compare and validation page tabs
  - Add refresh button
  - Add icons
- Allow DataTables to perform ajax requests instead of us doing it
  - Tables are shown immediately
  - Show a loading indicator during a load/reload
- Add animation when toggling site edit/changelog history panels
- Add icons to user nav dropdown for account history/logout
- Fix small bug with initial page load behavior